### PR TITLE
feat: add ability to delete all trainings

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "node-fetch": "^2.6.1"
   },
   "engines": {
-    "node": "18.x"
+    "node": "22.x"
   }
 }

--- a/public/script.js
+++ b/public/script.js
@@ -131,3 +131,32 @@ function showTrainingDetails(training) {
         <p><strong>Conseils :</strong> ${training.conseils || "?"}</p>
     `;
 }
+
+// Suppression de tous les entraînements de l'utilisateur
+async function deleteAllTrainings() {
+    const token = localStorage.getItem("jwt");
+    if (!token) {
+        alert("Vous devez être connecté !");
+        return;
+    }
+
+    const confirmation = confirm("Êtes-vous sûr de vouloir supprimer tous vos entraînements ?");
+    if (!confirmation) return;
+
+    try {
+        const response = await fetch("/api/deleteAll", {
+            method: "DELETE",
+            headers: { "Authorization": `Bearer ${token}` }
+        });
+
+        const data = await response.json();
+        alert(data.message || data.error || "Erreur inconnue");
+
+        if (response.ok) {
+            loadCalendar();
+        }
+    } catch (error) {
+        console.error("❌ Erreur lors de la suppression des entraînements :", error);
+        alert("Erreur lors de la suppression des entraînements.");
+    }
+}


### PR DESCRIPTION
## Summary
- add global `deleteAllTrainings` that deletes all trainings via API and refreshes calendar
- upgrade Node.js engine requirement to 22.x in `package.json`

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c8295629ac8331ab36c3445fc02ac6