### PR TITLE
Expose deleteAllTrainings globally for button access

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -160,3 +160,4 @@ async function deleteAllTrainings() {
         alert("Erreur lors de la suppression des entraînements.");
     }
 }
+window.deleteAllTrainings = deleteAllTrainings;


### PR DESCRIPTION
## Summary
- Expose `deleteAllTrainings` on the `window` object so UI buttons can trigger training deletions.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vercel: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8337e1ad48331b0b0bf480c947af0