### PR TITLE
Add OpenAI API key configuration validation

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 STRAVA_CLIENT_ID=149967
 STRAVA_CLIENT_SECRET=dc338cd28131533a6f9ecbf90eeac29295b75954
 STRAVA_REDIRECT_URI=https://running-opal-mu.vercel.app/api/strava/callback
+OPENAI_API_KEY=<votre_cle>
 

--- a/api/aiPlan.js
+++ b/api/aiPlan.js
@@ -1,8 +1,14 @@
 const fetch = require("node-fetch");
 
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+if (!OPENAI_API_KEY) {
+    throw new Error("OPENAI_API_KEY n'est pas défini. Ajoutez votre clé OpenAI dans le fichier .env.");
+}
+
 async function generateTrainingPlanAI(data, stravaActivities = []) {
     console.log("📡 Envoi des données à l'IA OpenAI...");
-    console.log("🔑 Clé API OpenAI utilisée :", process.env.OPENAI_API_KEY ? "OK" : "NON DÉFINIE");
+    console.log("🔑 Clé API OpenAI utilisée :", OPENAI_API_KEY ? "OK" : "NON DÉFINIE");
 
     const today = new Date();
     const endDate = new Date(data.dateEvent);
@@ -82,7 +88,7 @@ Réponds **exclusivement en JSON**, sans texte supplémentaire, balises Markdown
         const response = await fetch("https://api.openai.com/v1/chat/completions", {
             method: "POST",
             headers: {
-                "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`,
+                "Authorization": `Bearer ${OPENAI_API_KEY}`,
                 "Content-Type": "application/json"
             },
             body: JSON.stringify({


### PR DESCRIPTION
## Summary
- add the OpenAI API key placeholder to the environment configuration
- validate OPENAI_API_KEY at module load in the AI plan service and fail fast with a clear message when missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c83dbd354c8331908fe55cac4fe318