### PR TITLE
Implement logout handler for calendar page

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3,6 +3,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     loadCalendar();
     loadAthleteProfile();
 
+    const logoutButton = document.getElementById("logoutButton");
+    if (logoutButton) {
+        logoutButton.addEventListener("click", logout);
+    }
+
     document.getElementById("generate-plan").addEventListener("click", () => {
         window.location.href = "plan.html";
     });
@@ -159,4 +164,9 @@ async function deleteAllTrainings() {
         console.error("❌ Erreur lors de la suppression des entraînements :", error);
         alert("Erreur lors de la suppression des entraînements.");
     }
+}
+
+function logout() {
+    localStorage.removeItem("jwt");
+    window.location.href = "login.html";
 }


### PR DESCRIPTION
## Summary
- bind the logout button to a dedicated logout handler when the page loads
- implement the logout helper to clear the JWT from local storage and redirect to the login page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c83db02cd08331b7a148ef19af55ad